### PR TITLE
chore(updatecli): track geoipupdate and get-fileshare-signed-url.sh changes

### DIFF
--- a/updatecli/updatecli.d/geoipupdate.yaml
+++ b/updatecli/updatecli.d/geoipupdate.yaml
@@ -1,0 +1,57 @@
+---
+name: Bump `Geoipupdate`version`
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    name: Get latest geoipupdater version
+    kind: githubrelease
+    spec:
+      owner: "maxmind"
+      repository: "geoipupdate"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+
+targets:
+  updateDockerfileVersion:
+    name: Update the value of ARG GEOIPUPDATE_VERSION in the Dockerfile
+    sourceid: latestVersion
+    kind: dockerfile
+    spec:
+      file: ./Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GEOIPUPDATE_VERSION
+    scmid: default
+  updateCstVersion:
+    name: Update test harness with new `geoipupdater`` version
+    sourceid: latestVersion
+    kind: yaml
+    spec:
+      file: ./cst.yaml
+      key: $.commandTests[1].expectedError[0]
+    transformers:
+      - trimprefix: 'v'
+      - addprefix: '"geoipupdate '
+      - addsuffix: '"'
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump `Geoipupdate` version to {{ source "latestVersion" }}
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/get-fileshare-signed-url.yaml
+++ b/updatecli/updatecli.d/get-fileshare-signed-url.yaml
@@ -1,0 +1,39 @@
+---
+name: Keep `get-fileshare-signed-url.sh` up to date
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    name: Get latest get-fileshare-signed-url.sh version
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/jenkins-infra/pipeline-library/refs/heads/master/resources/get-fileshare-signed-url.sh
+
+targets:
+  update-get-fileshare-signed-url:
+    name: Update `get-fileshare-signed-url.sh` file
+    sourceid: latestVersion
+    kind: file
+    spec:
+      file: ./get-fileshare-signed-url.sh
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Update `get-fileshare-signed-url.sh` file
+    spec:
+      labels:
+        - dependencies


### PR DESCRIPTION
skeleton and first manifest to keep track of updates