### PR TITLE
feat(dockerfile): no root usage and dryrun

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certifi
 
 # AZCOPY INSTALL
 ARG AZCOPY_VERSION
+ARG user=azcopy
+ARG group=azcopy
+ARG uid=1000
+ARG gid=1000
+ARG user_home="/home/${user}"
+RUN groupadd -g ${gid} ${group} \
+    && useradd -l -d "${user_home}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}"
+
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; then \
@@ -23,7 +31,7 @@ RUN ARCH="$(uname -m)" && \
 && BIN_LOCATION="$(tar -tzf /tmp/azcopy.tgz | grep "/azcopy")" \
 && export BIN_LOCATION \
 && tar -xvzf /tmp/azcopy.tgz --strip-components=1 --directory=/usr/bin/ "$BIN_LOCATION" \
-&& chown root:root /usr/bin/azcopy \
+&& chown "${user}:${user}" /usr/bin/azcopy \
 && chmod +x /usr/bin/azcopy
 
 # AZ INSTALL
@@ -50,8 +58,10 @@ RUN ARCH="$(uname -m)" && \
 && BIN_LOCATION=$(tar -tzf /tmp/geoipupdate.tgz | grep "/geoipupdate$") \
 && export BIN_LOCATION \
 && tar -xvzf /tmp/geoipupdate.tgz --strip-components=1 --directory=/usr/bin/ "$BIN_LOCATION" \
-&& chown root:root /usr/bin/geoipupdate \
+&& chown "${user}:${user}" /usr/bin/geoipupdate \
 && chmod +x /usr/bin/geoipupdate
+
+USER "${user}"
 
 # TODO updatecli https://github.com/jenkins-infra/packer-images/blob/main/updatecli/updatecli.d/get-fileshare-signed-url.yml
 COPY get-fileshare-signed-url.sh /usr/bin/get-fileshare-signed-url.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN ARCH="$(uname -m)" && \
 && BIN_LOCATION="$(tar -tzf /tmp/azcopy.tgz | grep "/azcopy")" \
 && export BIN_LOCATION \
 && tar -xvzf /tmp/azcopy.tgz --strip-components=1 --directory=/usr/bin/ "$BIN_LOCATION" \
-&& chown "${user}:${user}" /usr/bin/azcopy \
 && chmod +x /usr/bin/azcopy
 
 # AZ INSTALL
@@ -58,12 +57,10 @@ RUN ARCH="$(uname -m)" && \
 && BIN_LOCATION=$(tar -tzf /tmp/geoipupdate.tgz | grep "/geoipupdate$") \
 && export BIN_LOCATION \
 && tar -xvzf /tmp/geoipupdate.tgz --strip-components=1 --directory=/usr/bin/ "$BIN_LOCATION" \
-&& chown "${user}:${user}" /usr/bin/geoipupdate \
 && chmod +x /usr/bin/geoipupdate
 
 USER "${user}"
 
-# TODO updatecli https://github.com/jenkins-infra/packer-images/blob/main/updatecli/updatecli.d/get-fileshare-signed-url.yml
 COPY get-fileshare-signed-url.sh /usr/bin/get-fileshare-signed-url.sh
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,13 +40,13 @@ fi
 
 ### GEOUPDATEIP
 echo "LAUNCH GEOIP UPDATE"
-if [ "${GEOIPUPDATE_DRYRUN-default}" == "default" ]; then #if GEOIPUPDATE_DRYRUN is not set
-    /usr/bin/geoipupdate --verbose --output --database-directory="${GEOIPUPDATE_DB_DIR}"
+if [ "${GEOIPUPDATE_DRYRUN:-false}" != "true" ]; then
+    geoipupdate --verbose --output --database-directory="${GEOIPUPDATE_DB_DIR}"
 else
-    echo "DRY MODE ON" #if GEOIPUPDATE_DRYRUN is set
+    echo "DRY-RUN ON"
     [[ "$(uname  || true)" == "Darwin" ]] && dateCmd="gdate" || dateCmd="date"
     currentUTCdatetime="$("${dateCmd}" --utc +"%Y%m%dT%H%MZ")"
-    echo "drymode" >"${GEOIPUPDATE_DB_DIR}/dryrun-${currentUTCdatetime}.mmdb"
+    echo "dry-run" >"${GEOIPUPDATE_DB_DIR}/dryrun-${currentUTCdatetime}.mmdb"
 fi
 echo "UPDATE DONE"
 

--- a/get-fileshare-signed-url.sh
+++ b/get-fileshare-signed-url.sh
@@ -22,7 +22,7 @@
 # - JENKINS_INFRA_FILESHARE_CLIENT_SECRET: the service principal client secret
 # - JENKINS_INFRA_FILESHARE_TENANT_ID: the file share tenant id
 # --------------------------------------------------------------------------------
-set -eu -o pipefail
+set -Eeu -o pipefail
 
 # Don't print any trace
 set +x

--- a/get-fileshare-signed-url.sh
+++ b/get-fileshare-signed-url.sh
@@ -55,6 +55,7 @@ fi
 [[ "$(uname  || true)" == "Darwin" ]] && dateCmd="gdate" || dateCmd="date"
 expiry="$("${dateCmd}" --utc --date "+ ${STORAGE_DURATION_IN_MINUTE} minutes" +"%Y-%m-%dT%H:%MZ")"
 
+
 # Generate a SAS token, remove double quotes around it and replace potential '/' by '%2F'
 token="$(az storage share generate-sas "${accountKeyArg[@]}" \
 --name "${STORAGE_FILESHARE}" \


### PR DESCRIPTION
avoid to use the user root by creating a specific user.
dump the logs within a temporary folder with a specific output in case of error within the stdout stream.
allow a dryrun mode to test and avoid geoip rate limit
