### PR TITLE
feat(entrypoint): add steps to ensure need for updates and rollout restart

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 set -Eeu -o pipefail
+echo "----------------------- Start "
+date
 
 GEOIPUPDATE_DB_DIR="$(mktemp -d)"
+# GEOIPUPDATE_DB_DIR="/tmp/TESTS"
 export GEOIPUPDATE_DB_DIR
 export GEOIPUPDATE_FREQUENCY=0
 
@@ -35,20 +38,6 @@ if [ -z "$JENKINS_INFRA_FILESHARE_TENANT_ID" ]; then
     exit 1
 fi
 
-### GEOUPDATEIP
-echo "LAUNCH GEOIP UPDATE"
-if [ "${GEOIPUPDATE_DRYRUN:-false}" != "true" ]; then
-    geoipupdate --verbose --output --database-directory="${GEOIPUPDATE_DB_DIR}"
-else
-    echo "DRY-RUN ON"
-    [[ "$(uname  || true)" == "Darwin" ]] && dateCmd="gdate" || dateCmd="date"
-    currentUTCdatetime="$("${dateCmd}" --utc +"%Y%m%dT%H%MZ")"
-    echo "dry-run" >"${GEOIPUPDATE_DB_DIR}/dryrun-${currentUTCdatetime}.mmdb"
-fi
-echo "UPDATE DONE"
-
-### AZCOPY
-
 if [ -z "$STORAGE_NAME" ]; then
     echo "ERROR: You must set the environment variable STORAGE_NAME!"
     exit 1
@@ -59,32 +48,90 @@ if [ -z "$STORAGE_FILESHARE" ]; then
     exit 1
 fi
 
-echo "LAUNCH AZCOPY"
+### Azure TOKEN
+echo "LAUNCH AZ token"
 echo "azure token"
 export STORAGE_DURATION_IN_MINUTE=5
 export STORAGE_PERMISSIONS=dlrw
 
 fileShareSignedUrl="$(get-fileshare-signed-url.sh)"
+urlWithoutToken=${fileShareSignedUrl%\?*}
+token=${fileShareSignedUrl#*\?}
 
-echo "azcopy copy"
+### AZ COPY dest to local
+echo "LAUNCH AZCOPY dest to local"
 AZCOPY_FOLDER="$(mktemp -d)"
 AZCOPY_LOG_LOCATION="${AZCOPY_FOLDER}"
 AZCOPY_JOB_PLAN_LOCATION="${AZCOPY_FOLDER}"
 export AZCOPY_LOG_LOCATION
 export AZCOPY_JOB_PLAN_LOCATION
+echo "local folder = ${GEOIPUPDATE_DB_DIR}/"
 set +e #do not failfast on error for azcopy
-azcopy copy \
+: | azcopy copy \
+    "${urlWithoutToken}/*?${token}" "${GEOIPUPDATE_DB_DIR}" \
     --skip-version-check `# Do not check for new azcopy versions (we have updatecli + puppet for this)` \
     --log-level=ERROR `# Do not write too much logs (I/O...)` \
-    "${GEOIPUPDATE_DB_DIR}/*.mmdb" "${fileShareSignedUrl}" \
+    --include-pattern='*.mmdb' `# only the mmdb databases files` \
 || \
-    cat "${AZCOPY_LOG_LOCATION}/.azcopy/*" #dump the logs in case of error during azcopy copy
+    { cat "${AZCOPY_LOG_LOCATION}/.azcopy/*"; exit 1; }   #dump the logs in case of error during azcopy copy
+set -e #set failfast back
+echo "AZCOPY dest to local done"
 
-echo "azcopy list"
-azcopy list \
-    --skip-version-check `# Do not check for new azcopy versions (we have updatecli + puppet for this)` \
-    "${fileShareSignedUrl}"
+echo "LISTING local: "
+ls -lt "${GEOIPUPDATE_DB_DIR}"
 
-echo "AZCOPY DONE"
+### GEOUPDATEIP
+echo "LAUNCH GEOIPUPDATE"
+GEOIPUPDATEJSONDIR="$(mktemp -d)"
+export GEOIPUPDATEJSONDIR
+if [ "${GEOIPUPDATE_DRYRUN:-false}" != "true" ]; then
+    geoipupdate --verbose --output "${GEOIPUPDATEJSONDIR}/geoipupdate.json" --database-directory="${GEOIPUPDATE_DB_DIR}"
+else
+    echo "DRY-RUN ON"
+    [[ "$(uname  || true)" == "Darwin" ]] && dateCmd="gdate" || dateCmd="date"
+    currentUTCdatetime="$("${dateCmd}" --utc +"%Y%m%dT%H%MZ")"
+    echo "dry-run" >"${GEOIPUPDATE_DB_DIR}/dryrun-${currentUTCdatetime}.mmdb"
+    echo '[{"edition_id":"GeoLite2-ASN","old_hash":"c54b6e64478adfd010c7a86db310033f","new_hash":"857a0cf8118b9961cf6789e1842bce2a","modified_at":1733403617,"checked_at":1733756616},{"edition_id":"GeoLite2-City","old_hash":"34a6a0ec4018c74a503134980c154502","new_hash":"fb3449d8252f74eac39fc55c32c19879","modified_at":1733501742,"checked_at":1733756620},{"edition_id":"GeoLite2-Country","old_hash":"627a1d220b5ef844e0f0f174a0161cd7","new_hash":"27b1f57ae9dd56e1923f5d458514794c","modified_at":1733506208,"checked_at":1733756621}]' > "${GEOIPUPDATEJSONDIR}/geoipupdate.json"
+    # echo '[{"edition_id":"GeoLite2-ASN","old_hash":"857a0cf8118b9961cf6789e1842bce2a","new_hash":"857a0cf8118b9961cf6789e1842bce2a","checked_at":1733760216},{"edition_id":"GeoLite2-City","old_hash":"fb3449d8252f74eac39fc55c32c19879","new_hash":"fb3449d8252f74eac39fc55c32c19879","checked_at":1733760216},{"edition_id":"GeoLite2-Country","old_hash":"27b1f57ae9dd56e1923f5d458514794c","new_hash":"27b1f57ae9dd56e1923f5d458514794c","checked_at":1733760216}]' > "${GEOIPUPDATEJSONDIR}/geoipupdate.json"
+    echo "json saved to file ${GEOIPUPDATEJSONDIR}/geoipupdate.json"
+    cat "${GEOIPUPDATEJSONDIR}/geoipupdate.json"
+fi
+echo "GEOIPUPDATE DONE"
+
+### PARSING JSON copy if hash have changed
+# > /dev/null to avoid multiple true in output but keep errors output
+if jq -e '.[] | select(.old_hash != .new_hash)' "${GEOIPUPDATEJSONDIR}/geoipupdate.json" > /dev/null; then
+    echo "DATA CHANGED, update needed"
+    ### AZCOPY local to dest
+    echo "LAUNCH AZCOPY local to dest"
+    set +e #do not failfast on error for azcopy
+    : | azcopy copy \
+        "${GEOIPUPDATE_DB_DIR}/*" "${fileShareSignedUrl}" \
+        --skip-version-check `# Do not check for new azcopy versions (we have updatecli + puppet for this)` \
+        --log-level=ERROR `# Do not write too much logs (I/O...)` \
+        --include-pattern='*.mmdb' `# only the mmdb databases files` \
+        --overwrite="ifSourceNewer" `# Upload if and only if the updategeoip as updated the files` \
+    || \
+        { cat "${AZCOPY_LOG_LOCATION}/.azcopy/*"; exit 1; }   #dump the logs in case of error during azcopy copy
+    set -e #set failfast back
+    ### AZCOPY List to ensure files are present on destination
+    echo "azcopy list"
+    azcopy list \
+        --skip-version-check `# Do not check for new azcopy versions (we have updatecli + puppet for this)` \
+        "${fileShareSignedUrl}"
+    echo "AZCOPY local to dest done"
+
+    echo "ROLLOUT RESTART"
+        kubectl -n updates-jenkins-io   rollout restart deployment updates-jenkins-io-content-secured-mirrorbits &&
+        kubectl -n updates-jenkins-io   rollout status  deployment updates-jenkins-io-content-secured-mirrorbits
+        kubectl -n updates-jenkins-io   rollout restart deployment updates-jenkins-io-content-unsecured-mirrorbits &&
+        kubectl -n updates-jenkins-io   rollout status  deployment updates-jenkins-io-content-unsecured-mirrorbits
+        kubectl -n get-jenkins-io       rollout restart deployment get-jenkins-io-mirrorbits &&
+        kubectl -n get-jenkins-io       rollout status  deployment get-jenkins-io-mirrorbits
+    echo "ROLLOUT RESTART DONE"
+    
+else
+    echo "Data are up to date"
+fi
 
 exit 0


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4441

This PR add a check on the data from geoipupdater by getting it first from the fileshare, then running the geoipupdate script against it and parsing the json to check if an update is needed.
If so, we proceed to the upload and then run a rollout restart.

This PR will need a change on the helmchart to allow rollout restart in the RBAC on 2 others namespaces