### PR TITLE
chore(azcopy) change installation method to package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends jq wget ca-cert
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# User and Group
+ARG user=azcopy
+ARG group=azcopy
+ARG uid=1000
+ARG gid=1000
+ARG user_home="/home/${user}"
+RUN groupadd -g ${gid} ${group} \
+    && useradd -l -d "${user_home}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}"
+
 # AZCOPY INSTALL
 ARG AZCOPY_VERSION=10.27.1
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,14 @@ ARG AZ_VERSION=2.67.0
 ARG KUBECTL_VERSION=1.26.12
 
 FROM ubuntu:22.04
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends jq wget ca-certificates gnupg lsb-release\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# User and Group
 ARG user=azcopy
 ARG group=azcopy
 ARG uid=1000
@@ -18,9 +20,7 @@ ARG user_home="/home/${user}"
 RUN groupadd -g ${gid} ${group} \
     && useradd -l -d "${user_home}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}"
 
-# AZCOPY INSTALL
 ARG AZCOPY_VERSION=10.27.1
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN rep_config_pkg="$(mktemp)" \
     # Download and install the repository configuration package.
     && wget -qO- "https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb" -O "${rep_config_pkg}" \
@@ -34,9 +34,7 @@ RUN rep_config_pkg="$(mktemp)" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# AZ INSTALL
 ARG AZ_VERSION=2.67.0
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mkdir -p /etc/apt/keyrings && \
     wget --quiet --output-document - "https://packages.microsoft.com/keys/microsoft.asc" | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \
     chmod go+r /etc/apt/keyrings/microsoft.gpg && \
@@ -44,9 +42,7 @@ RUN mkdir -p /etc/apt/keyrings && \
     printf 'Types: deb\nURIs: https://packages.microsoft.com/repos/azure-cli/\nSuites: %s\nComponents: main\nArchitectures: %s\nSigned-by: /etc/apt/keyrings/microsoft.gpg' "${AZ_DIST}" "$(dpkg --print-architecture)" | tee /etc/apt/sources.list.d/azure-cli.sources && \
     apt-get update && apt-get install -y --no-install-recommends azure-cli="${AZ_VERSION}-1~${AZ_DIST}" && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# GEOIPUPDATE INSTALL
 ARG GEOIPUPDATE_VERSION=v7.1.0
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; then \
         DOWNLOAD_URL="https://github.com/maxmind/geoipupdate/releases/download/${GEOIPUPDATE_VERSION}/geoipupdate_${GEOIPUPDATE_VERSION#v}_linux_amd64.tar.gz"; \
@@ -61,9 +57,7 @@ RUN ARCH="$(uname -m)" && \
 && tar -xvzf /tmp/geoipupdate.tgz --strip-components=1 --directory=/usr/bin/ "$BIN_LOCATION" \
 && chmod +x /usr/bin/geoipupdate
 
-# kubectl install
 ARG KUBECTL_VERSION
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; then \
         DOWNLOAD_URL="https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends jq wget ca-cert
 
 # AZCOPY INSTALL
 ARG AZCOPY_VERSION=10.27.1
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN rep_config_pkg="$(mktemp)" \
     # Download and install the repository configuration package.
-    && curl --silent --show-error --location --output "${rep_config_pkg}" \
-    https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb \
+    && wget -qO- "https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb" -O "${rep_config_pkg}" \
     && dpkg --install "${rep_config_pkg}" \
     && rm -f "${rep_config_pkg}" \
     && apt-get update --quiet \
@@ -27,6 +27,7 @@ RUN rep_config_pkg="$(mktemp)" \
 
 # AZ INSTALL
 ARG AZ_VERSION=2.67.0
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mkdir -p /etc/apt/keyrings && \
     wget --quiet --output-document - "https://packages.microsoft.com/keys/microsoft.asc" | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \
     chmod go+r /etc/apt/keyrings/microsoft.gpg && \
@@ -53,6 +54,7 @@ RUN ARCH="$(uname -m)" && \
 
 # kubectl install
 ARG KUBECTL_VERSION
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; then \
         DOWNLOAD_URL="https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl"; \

--- a/updatecli/updatecli.d/azcopy.yaml
+++ b/updatecli/updatecli.d/azcopy.yaml
@@ -15,12 +15,13 @@ scms:
 
 sources:
   latestVersion:
-    kind: shell
-    name: Get the latest `azcopy` (full) version
+    kind: githubrelease
+    name: Get the latest `azcopy` version
     spec:
-      command: bash -c 'basename "$(dirname "$(curl https://aka.ms/downloadazcopy-v10-linux --write-out "%{redirect_url}" --output /dev/null --silent --fail --show-error)" )"'
-    transformers:
-      - trimprefix: 'release-'
+      owner: Azure
+      repository: azure-storage-azcopy
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
 
 targets:
   updateDockerfileVersion:
@@ -41,9 +42,7 @@ targets:
       file: ./cst.yaml
       key: $.commandTests[0].expectedOutput[0]
     transformers:
-      - findsubmatch:
-          pattern: "(.*)-(.*)"
-          captureindex: 1
+      - trimprefix: 'v'
       - addprefix: '"azcopy version '
       - addsuffix: '"'
     scmid: default

--- a/updatecli/updatecli.d/azcopy.yaml
+++ b/updatecli/updatecli.d/azcopy.yaml
@@ -22,6 +22,8 @@ sources:
       repository: azure-storage-azcopy
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
+    transformers:
+      - trimprefix: 'v'
 
 targets:
   updateDockerfileVersion:
@@ -42,7 +44,6 @@ targets:
       file: ./cst.yaml
       key: $.commandTests[0].expectedOutput[0]
     transformers:
-      - trimprefix: 'v'
       - addprefix: '"azcopy version '
       - addsuffix: '"'
     scmid: default


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4471
lets change the install for azcopy to apt-get install

the updatecli have been changed to match