### PR TITLE
chore(updatecli) tracks `semver` version of azcopy

### DIFF
--- a/updatecli/updatecli.d/azcopy.yaml
+++ b/updatecli/updatecli.d/azcopy.yaml
@@ -22,6 +22,8 @@ sources:
       repository: azure-storage-azcopy
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
+      versionFilter:
+        kind: semver
     transformers:
       - trimprefix: 'v'
 


### PR DESCRIPTION
This PR  tracks `semver` version of azcopy since we don't want to bump to "preview" versions of `azcopy`